### PR TITLE
feat: enable touch drag for pieces

### DIFF
--- a/components/game/GameBoard.tsx
+++ b/components/game/GameBoard.tsx
@@ -25,6 +25,7 @@ export function GameBoard({ mode, difficulty, onBackToMenu }: GameBoardProps) {
   const { theme } = useTheme()
   const [isAIThinking, setIsAIThinking] = useState(false)
   const [isProcessingMove, setIsProcessingMove] = useState(false)
+  const [dragOver, setDragOver] = useState<{ row: number; col: number } | null>(null)
 
   useEffect(() => {
     if (mode === "bot" && state.currentPlayer === "black" && state.gameStatus === "playing" && !isAIThinking) {
@@ -128,6 +129,23 @@ export function GameBoard({ mode, difficulty, onBackToMenu }: GameBoardProps) {
 
     dispatch({ type: "SELECT_PIECE", piece: null })
     dispatch({ type: "SET_VALID_MOVES", moves: [] })
+  }
+
+  const handleDragStart = (row: number, col: number) => {
+    handleSquareClick(row, col)
+  }
+
+  const handleDragOver = (row: number, col: number) => {
+    if (row >= 0 && col >= 0) {
+      setDragOver({ row, col })
+    } else {
+      setDragOver(null)
+    }
+  }
+
+  const handleDrop = (row: number, col: number) => {
+    handleSquareClick(row, col)
+    setDragOver(null)
   }
 
   const resetGame = () => {
@@ -267,6 +285,10 @@ export function GameBoard({ mode, difficulty, onBackToMenu }: GameBoardProps) {
                       isSelected={isSelectedSquare(rowIndex, colIndex)}
                       isValidMove={isValidMoveSquare(rowIndex, colIndex)}
                       onClick={() => handleSquareClick(rowIndex, colIndex)}
+                      onDragStart={handleDragStart}
+                      onDragOver={handleDragOver}
+                      onDrop={handleDrop}
+                      isDragTarget={dragOver?.row === rowIndex && dragOver?.col === colIndex}
                     />
                   )),
                 )}


### PR DESCRIPTION
## Summary
- allow dragging checkers with touch by tracking drag start, move and drop
- wire GameBoard to highlight drag targets and drop pieces

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689df63fac9c83318147ce27cbf7421e