### PR TITLE
feat: track online game results

### DIFF
--- a/components/game/GameProvider.tsx
+++ b/components/game/GameProvider.tsx
@@ -139,7 +139,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     board: initializeBoard(),
   })
 
-  const { recordWin, recordLoss, recordDraw } = useGameStats()
+  const { recordWin, recordLoss, recordDraw, recordOnlineWin, recordOnlineLoss, recordOnlineDraw } = useGameStats()
   const statsRecordedRef = useRef(false)
 
   useEffect(() => {
@@ -150,25 +150,41 @@ export function GameProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (state.gameStatus !== "playing" && !statsRecordedRef.current) {
-      // Отслеживаем статистику только в режиме против бота
       if (state.gameMode === "bot") {
         if (state.gameStatus === "white-wins") {
-          // Игрок (белые) выиграл против бота
           recordWin()
           statsRecordedRef.current = true
         } else if (state.gameStatus === "black-wins") {
-          // Бот (черные) выиграл против игрока
           recordLoss()
           statsRecordedRef.current = true
         } else if (state.gameStatus === "draw") {
           recordDraw()
           statsRecordedRef.current = true
         }
+      } else if (state.gameMode === "online") {
+        if (state.gameStatus === "white-wins") {
+          recordOnlineWin()
+          statsRecordedRef.current = true
+        } else if (state.gameStatus === "black-wins") {
+          recordOnlineLoss()
+          statsRecordedRef.current = true
+        } else if (state.gameStatus === "draw") {
+          recordOnlineDraw()
+          statsRecordedRef.current = true
+        }
       }
       // В локальном режиме статистика не ведется (играют два человека)
-      // В онлайн режиме статистика будет добавлена позже
     }
-  }, [state.gameStatus, state.gameMode, recordWin, recordLoss, recordDraw])
+  }, [
+    state.gameStatus,
+    state.gameMode,
+    recordWin,
+    recordLoss,
+    recordDraw,
+    recordOnlineWin,
+    recordOnlineLoss,
+    recordOnlineDraw,
+  ])
 
   const setGameMode = (mode: GameMode) => {
     dispatch({ type: "SET_GAME_STATE", state: { gameMode: mode } })

--- a/hooks/use-game-stats.ts
+++ b/hooks/use-game-stats.ts
@@ -42,6 +42,18 @@ export function useGameStats() {
     localStorage.setItem("starcheckers-stats", JSON.stringify(newStats))
   }
 
+  const sendResultToServer = async (result: "win" | "loss" | "draw") => {
+    try {
+      await fetch("/api/history", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ result }),
+      })
+    } catch (error) {
+      console.error("Failed to send game result", error)
+    }
+  }
+
   const recordWin = () => {
     const newStats = {
       ...stats,
@@ -77,12 +89,30 @@ export function useGameStats() {
     saveStats(defaultStats)
   }
 
+  const recordOnlineWin = async () => {
+    recordWin()
+    await sendResultToServer("win")
+  }
+
+  const recordOnlineLoss = async () => {
+    recordLoss()
+    await sendResultToServer("loss")
+  }
+
+  const recordOnlineDraw = async () => {
+    recordDraw()
+    await sendResultToServer("draw")
+  }
+
   return {
     stats,
     isLoaded,
     recordWin,
     recordLoss,
     recordDraw,
+    recordOnlineWin,
+    recordOnlineLoss,
+    recordOnlineDraw,
     resetStats,
   }
 }


### PR DESCRIPTION
## Summary
- record online wins, losses and draws while persisting stats
- invoke online stat updates when online games finish

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68a32e06f5208331b083175fc057680c