### PR TITLE
Synchronize room data between REST and Socket.IO

### DIFF
--- a/components/game/GameBoard.tsx
+++ b/components/game/GameBoard.tsx
@@ -42,9 +42,16 @@ export function GameBoard({ mode, difficulty, onBackToMenu }: GameBoardProps) {
       .then((res) => {
         setRoomId(res.roomId)
         if (res.color) setPlayerColor(res.color)
+        if (socket.current) {
+          if (joinRoomId) {
+            socket.current.emit("joinGame", res.roomId)
+          } else {
+            socket.current.emit("createGame", res.roomId)
+          }
+        }
       })
       .catch(console.error)
-  }, [mode, user, initData, roomId, searchParams])
+  }, [mode, user, initData, roomId, searchParams, socket])
 
   useEffect(() => {
     if (

--- a/lib/room-store.ts
+++ b/lib/room-store.ts
@@ -1,18 +1,67 @@
+import { randomUUID } from "crypto"
+import type { Piece } from "@/components/game/GameProvider"
+
 export type Player = {
   id: number
   color: "white" | "black"
+  socketId?: string
 }
+
+export type GameStatus = "playing" | "white-wins" | "black-wins" | "draw"
 
 export interface Room {
   id: string
+  board: (Piece | null)[][]
+  currentPlayer: "white" | "black"
   players: Player[]
+  gameStatus: GameStatus
 }
 
-const rooms = new Map<string, Room>()
+export const rooms = new Map<string, Room>()
+
+function initializeBoard(): (Piece | null)[][] {
+  const board: (Piece | null)[][] = Array(8)
+    .fill(null)
+    .map(() => Array(8).fill(null))
+
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 8; col++) {
+      if ((row + col) % 2 === 1) {
+        board[row][col] = {
+          id: `black-${row}-${col}`,
+          type: "regular",
+          color: "black",
+          position: { row, col },
+        }
+      }
+    }
+  }
+
+  for (let row = 5; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      if ((row + col) % 2 === 1) {
+        board[row][col] = {
+          id: `white-${row}-${col}`,
+          type: "regular",
+          color: "white",
+          position: { row, col },
+        }
+      }
+    }
+  }
+
+  return board
+}
 
 export function createRoom(player: Player): Room {
-  const id = Math.random().toString(36).slice(2, 8)
-  const room: Room = { id, players: [player] }
+  const id = randomUUID()
+  const room: Room = {
+    id,
+    board: initializeBoard(),
+    currentPlayer: "white",
+    players: [player],
+    gameStatus: "playing",
+  }
   rooms.set(id, room)
   return room
 }
@@ -26,4 +75,28 @@ export function joinRoom(id: string, player: Player): Room | null {
 
 export function getRoom(id: string): Room | undefined {
   return rooms.get(id)
+}
+
+export function setPlayerSocket(roomId: string, color: "white" | "black", socketId: string) {
+  const room = rooms.get(roomId)
+  if (!room) return
+  const player = room.players.find((p) => p.color === color)
+  if (player) player.socketId = socketId
+}
+
+export function leaveRoom(roomId: string, socketId: string) {
+  const room = rooms.get(roomId)
+  if (!room) return
+  room.players = room.players.filter((p) => p.socketId !== socketId)
+  if (room.players.length === 0) {
+    rooms.delete(roomId)
+  }
+}
+
+export function findRoomsBySocket(socketId: string): string[] {
+  const ids: string[] = []
+  for (const [id, room] of rooms) {
+    if (room.players.some((p) => p.socketId === socketId)) ids.push(id)
+  }
+  return ids
 }


### PR DESCRIPTION
## Summary
- emit socket events after REST create/join game responses
- use shared room store for Socket.IO and REST endpoints
- handle game state through unified room data

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3456272948331b4cede896685e781