### PR TITLE
Pass room code when joining online game

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,10 +15,12 @@ export default function StarCheckersApp() {
   const [currentScreen, setCurrentScreen] = useState<GameScreen>("menu")
   const [gameMode, setGameMode] = useState<GameMode>("bot")
   const [difficulty, setDifficulty] = useState<Difficulty>("medium")
+  const [roomCode, setRoomCode] = useState<string | null>(null)
 
-  const startGame = (mode: GameMode, diff?: Difficulty) => {
+  const startGame = (mode: GameMode, diff?: Difficulty, code?: string) => {
     setGameMode(mode)
     if (diff) setDifficulty(diff)
+    setRoomCode(code ?? null)
     setCurrentScreen("game")
   }
 
@@ -31,7 +33,9 @@ export default function StarCheckersApp() {
         <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-100 dark:from-amber-950 dark:to-orange-950">
           {currentScreen === "menu" && <MainMenu onStartGame={startGame} onOpenSettings={goToSettings} />}
 
-          {currentScreen === "game" && <GameBoard mode={gameMode} difficulty={difficulty} onBackToMenu={goToMenu} />}
+          {currentScreen === "game" && (
+            <GameBoard mode={gameMode} difficulty={difficulty} roomCode={roomCode ?? undefined} onBackToMenu={goToMenu} />
+          )}
 
           {currentScreen === "settings" && <SettingsMenu onBack={goToMenu} />}
         </div>

--- a/components/game/GameBoard.tsx
+++ b/components/game/GameBoard.tsx
@@ -5,7 +5,6 @@ import { useGame } from "./GameProvider"
 import { useAudio } from "./AudioProvider"
 import { useTelegram } from "../telegram/TelegramProvider"
 import { createGame, joinGame } from "@/lib/api"
-import { useSearchParams } from "next/navigation"
 import { useTheme } from "@/hooks/use-theme"
 import { BoardSquare } from "./BoardSquare"
 import { GameLogic } from "@/lib/game-logic"
@@ -17,14 +16,14 @@ import { useEffect, useState } from "react"
 interface GameBoardProps {
   mode: GameMode
   difficulty: Difficulty
+  roomCode?: string
   onBackToMenu: () => void
 }
 
-export function GameBoard({ mode, difficulty, onBackToMenu }: GameBoardProps) {
+export function GameBoard({ mode, difficulty, roomCode, onBackToMenu }: GameBoardProps) {
   const { state, dispatch, socket } = useGame()
   const { playSound, initializeAudio } = useAudio()
   const { hapticFeedback, user, initData } = useTelegram()
-  const searchParams = useSearchParams()
   const [roomId, setRoomId] = useState<string | null>(null)
   const [playerColor, setPlayerColor] = useState<"white" | "black">("white")
   const { theme } = useTheme()
@@ -34,7 +33,7 @@ export function GameBoard({ mode, difficulty, onBackToMenu }: GameBoardProps) {
 
   useEffect(() => {
     if (mode !== "online" || !user || !initData || roomId) return
-    const joinRoomId = searchParams.get("room")
+    const joinRoomId = roomCode
     const action = joinRoomId
       ? joinGame(joinRoomId, user, initData)
       : createGame(user, initData)
@@ -51,7 +50,7 @@ export function GameBoard({ mode, difficulty, onBackToMenu }: GameBoardProps) {
         }
       })
       .catch(console.error)
-  }, [mode, user, initData, roomId, searchParams, socket])
+  }, [mode, user, initData, roomId, roomCode, socket])
 
   useEffect(() => {
     if (

--- a/components/game/MainMenu.tsx
+++ b/components/game/MainMenu.tsx
@@ -7,7 +7,7 @@ import { useAudio } from "./AudioProvider"
 import { LoadingSpinner } from "./LoadingSpinner"
 
 interface MainMenuProps {
-  onStartGame: (mode: GameMode, difficulty?: Difficulty) => void
+  onStartGame: (mode: GameMode, difficulty?: Difficulty, roomCode?: string) => void
   onOpenSettings: () => void
 }
 
@@ -18,9 +18,9 @@ export function MainMenu({ onStartGame, onOpenSettings }: MainMenuProps) {
   const [onlineStep, setOnlineStep] = useState<"none" | "options" | "waiting" | "join">("none")
   const [roomCode, setRoomCode] = useState("")
 
-  const handleStartGame = (mode: GameMode, difficulty?: Difficulty) => {
+  const handleStartGame = (mode: GameMode, difficulty?: Difficulty, roomCode?: string) => {
     initializeAudio()
-    onStartGame(mode, difficulty)
+    onStartGame(mode, difficulty, roomCode)
   }
 
   return (
@@ -215,7 +215,7 @@ export function MainMenu({ onStartGame, onOpenSettings }: MainMenuProps) {
                       />
                       <div className="flex gap-2">
                         <button
-                          onClick={() => handleStartGame("online")}
+                          onClick={() => handleStartGame("online", undefined, roomCode)}
                           className="flex-1 h-10 rounded-2xl bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-white/20 text-white hover:scale-105 transition-all"
                         >
                           Присоединиться


### PR DESCRIPTION
## Summary
- forward room code from MainMenu to startGame when joining online
- store room code in app/page and pass it to GameBoard
- use provided room code in GameBoard to join existing rooms

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a347a8d9c483318f0342744c4e02d6