### PR TITLE
feat: add history api endpoint

### DIFF
--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,0 +1,30 @@
+type GameResult = "win" | "loss" | "draw"
+
+interface HistoryEntry {
+  result: GameResult
+  timestamp: number
+}
+
+const history: HistoryEntry[] = []
+
+export async function POST(req: Request) {
+  try {
+    const { result } = (await req.json()) as { result?: GameResult }
+
+    if (result !== "win" && result !== "loss" && result !== "draw") {
+      return new Response(JSON.stringify({ error: "Invalid result" }), { status: 400 })
+    }
+
+    history.push({ result, timestamp: Date.now() })
+
+    return Response.json({ success: true })
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid request" }), { status: 400 })
+  }
+}
+
+// Simple helper to inspect saved history during development/tests
+export function getHistory() {
+  return history
+}
+

--- a/hooks/use-game-stats.ts
+++ b/hooks/use-game-stats.ts
@@ -44,14 +44,14 @@ export function useGameStats(userId?: number) {
   }
 
   const sendResultToServer = async (result: "win" | "loss" | "draw") => {
-    try {
-      await fetch("/api/history", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ result }),
-      })
-    } catch (error) {
-      console.error("Failed to send game result", error)
+    const res = await fetch("/api/history", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ result }),
+    })
+
+    if (!res.ok) {
+      throw new Error("Failed to send game result")
     }
   }
 
@@ -92,17 +92,29 @@ export function useGameStats(userId?: number) {
 
   const recordOnlineWin = async () => {
     recordWin()
-    await sendResultToServer("win")
+    try {
+      await sendResultToServer("win")
+    } catch (error) {
+      console.error("Failed to record win online", error)
+    }
   }
 
   const recordOnlineLoss = async () => {
     recordLoss()
-    await sendResultToServer("loss")
+    try {
+      await sendResultToServer("loss")
+    } catch (error) {
+      console.error("Failed to record loss online", error)
+    }
   }
 
   const recordOnlineDraw = async () => {
     recordDraw()
-    await sendResultToServer("draw")
+    try {
+      await sendResultToServer("draw")
+    } catch (error) {
+      console.error("Failed to record draw online", error)
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- add `/api/history` POST route storing match results in memory
- surface server errors in `recordOnlineWin/Loss/Draw`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a348ade44c8331a24a766bea7c20c6