### PR TITLE
Ensure online mode setup before rendering game board

### DIFF
--- a/components/game/GameBoard.tsx
+++ b/components/game/GameBoard.tsx
@@ -32,7 +32,7 @@ export function GameBoard({ mode, difficulty, roomCode, onBackToMenu }: GameBoar
   const [isProcessingMove, setIsProcessingMove] = useState(false)
 
   useEffect(() => {
-    if (mode !== "online" || !user || !initData || roomId) return
+    if (mode !== "online" || !user || !initData || roomId || !socket.current) return
     const joinRoomId = roomCode
     const action = joinRoomId
       ? joinGame(joinRoomId, user, initData)

--- a/components/game/MainMenu.tsx
+++ b/components/game/MainMenu.tsx
@@ -5,6 +5,7 @@ import { useGameStats } from "@/hooks/use-game-stats"
 import { useState } from "react"
 import { useAudio } from "./AudioProvider"
 import { LoadingSpinner } from "./LoadingSpinner"
+import { useGame } from "./GameProvider"
 
 interface MainMenuProps {
   onStartGame: (mode: GameMode, difficulty?: Difficulty, roomCode?: string) => void
@@ -14,12 +15,16 @@ interface MainMenuProps {
 export function MainMenu({ onStartGame, onOpenSettings }: MainMenuProps) {
   const { stats } = useGameStats()
   const { initializeAudio } = useAudio()
+  const { setGameMode } = useGame()
   const [hoveredButton, setHoveredButton] = useState<string | null>(null)
   const [onlineStep, setOnlineStep] = useState<"none" | "options" | "waiting" | "join">("none")
   const [roomCode, setRoomCode] = useState("")
 
   const handleStartGame = (mode: GameMode, difficulty?: Difficulty, roomCode?: string) => {
     initializeAudio()
+    if (mode === "online") {
+      setGameMode("online")
+    }
     onStartGame(mode, difficulty, roomCode)
   }
 


### PR DESCRIPTION
## Summary
- set GameProvider mode to `online` in MainMenu before switching to the game screen
- wait for socket availability in GameBoard before creating or joining rooms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a34cc9a0e083318cec8b29dfa79271