### PR TITLE
Use gameId in online move payload

### DIFF
--- a/components/game/GameBoard.tsx
+++ b/components/game/GameBoard.tsx
@@ -177,7 +177,7 @@ export function GameBoard({ mode, difficulty, roomCode, onBackToMenu }: GameBoar
 
         if (mode === "online" && socket.current && state.roomId) {
           socket.current.emit("move", {
-            roomId: state.roomId,
+            gameId: state.roomId,
             from: fromPosition,
             to: position,
           })


### PR DESCRIPTION
## Summary
- emit game moves with `gameId` instead of `roomId`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38f054cb88331abf3483c71872589