### PR TITLE
Display room code and share option for online games

### DIFF
--- a/components/game/MainMenu.tsx
+++ b/components/game/MainMenu.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 import { useAudio } from "./AudioProvider"
 import { LoadingSpinner } from "./LoadingSpinner"
 import { useGame } from "./GameProvider"
+import { RoomCodeToast } from "./RoomCodeToast"
 
 interface MainMenuProps {
   onStartGame: (mode: GameMode, difficulty?: Difficulty, roomCode?: string) => void
@@ -15,7 +16,7 @@ interface MainMenuProps {
 export function MainMenu({ onStartGame, onOpenSettings }: MainMenuProps) {
   const { stats } = useGameStats()
   const { initializeAudio } = useAudio()
-  const { setGameMode } = useGame()
+  const { state, setGameMode } = useGame()
   const [hoveredButton, setHoveredButton] = useState<string | null>(null)
   const [onlineStep, setOnlineStep] = useState<"none" | "options" | "waiting" | "join">("none")
   const [roomCode, setRoomCode] = useState("")
@@ -29,7 +30,9 @@ export function MainMenu({ onStartGame, onOpenSettings }: MainMenuProps) {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <>
+      {state.roomId && !state.opponentColor && <RoomCodeToast roomId={state.roomId} />}
+      <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
       {/* Animated background elements */}
       <div className="absolute inset-0">
         {/* Floating orbs with different animation speeds */}
@@ -257,5 +260,6 @@ export function MainMenu({ onStartGame, onOpenSettings }: MainMenuProps) {
         </div>
       </div>
     </div>
+  </>
   )
 }

--- a/components/game/RoomCodeToast.tsx
+++ b/components/game/RoomCodeToast.tsx
@@ -1,0 +1,46 @@
+"use client"
+import { useState } from "react"
+
+interface RoomCodeToastProps {
+  roomId: string
+  position?: "top" | "bottom"
+  onClose?: () => void
+}
+
+export function RoomCodeToast({ roomId, position = "top", onClose }: RoomCodeToastProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(roomId)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const posClass = position === "bottom" ? "bottom-4" : "top-4"
+
+  return (
+    <div className={`fixed ${posClass} left-1/2 -translate-x-1/2 z-50`}>
+      <div className="liquid-glass flex items-center gap-2 px-4 py-2 rounded-xl">
+        <span className="font-mono text-sm text-white">{roomId}</span>
+        <button
+          onClick={handleCopy}
+          className="bg-white/10 hover:bg-white/20 text-white text-xs px-2 py-1 rounded-lg transition-colors"
+        >
+          {copied ? "Скопировано" : "Копировать"}
+        </button>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="text-white/60 hover:text-white text-xs px-1"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show room code in a toast after creating an online game
- allow copying and sharing the room code from the main menu until an opponent joins
- extract reusable room code toast component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a39007b644833186b62840ffea07bd