### PR TITLE
Ensure opponent color is derived correctly on join

### DIFF
--- a/components/game/GameProvider.tsx
+++ b/components/game/GameProvider.tsx
@@ -191,9 +191,13 @@ export function GameProvider({ children }: { children: ReactNode }) {
       })
 
       socket.on("playerJoined", (data: { player: PieceColor }) => {
+        const opponentColor =
+          data.player === state.playerColor
+            ? data.player === "white" ? "black" : "white"
+            : data.player
         dispatch({
           type: "SET_GAME_STATE",
-          state: { opponentColor: data.player },
+          state: { opponentColor },
         })
       })
 
@@ -219,7 +223,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
       socketRef.current?.disconnect()
       socketRef.current = null
     }
-  }, [state.gameMode, dispatch])
+  }, [state.gameMode, state.playerColor, dispatch])
 
   useEffect(() => {
     if (state.gameStatus === "playing") {


### PR DESCRIPTION
## Summary
- compute opponent color by comparing the joined player's color with the local player's color
- reinitialize socket handlers when player color changes by including `state.playerColor` in effect dependencies

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3958fb7288331b632ba65ab895d91