### PR TITLE
Replace socket cleanup to use direct socket reference

### DIFF
--- a/components/game/GameBoard.tsx
+++ b/components/game/GameBoard.tsx
@@ -56,8 +56,8 @@ export function GameBoard({ mode, difficulty, roomCode, onBackToMenu }: GameBoar
     if (cleanupRef.current) return
     cleanupRef.current = true
 
-    if (mode === "online" && socket.current && state.roomId) {
-      socket.current.emit("leave", state.roomId)
+    if (mode === "online" && socket && state.roomId) {
+      socket.emit("leave", state.roomId)
     }
 
     dispatch({


### PR DESCRIPTION
## Summary
- Use direct `socket` reference in online cleanup and emission

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a43799b8cc8331bb4730330f42c27e