### PR TITLE
Sync online move handling with server state

### DIFF
--- a/components/game/GameProvider.tsx
+++ b/components/game/GameProvider.tsx
@@ -214,9 +214,27 @@ export function GameProvider({ children }: { children: ReactNode }) {
         })
       })
 
-      activeSocket.on("move", (data: { from: Position; to: Position }) => {
-        dispatch({ type: "MOVE_PIECE", from: data.from, to: data.to })
-      })
+      activeSocket.on(
+        "move",
+        (
+          data: {
+            from: Position
+            to: Position
+            board: (Piece | null)[][]
+            currentPlayer: PieceColor
+            gameStatus: GameState["gameStatus"]
+          },
+        ) => {
+          dispatch({
+            type: "SET_GAME_STATE",
+            state: {
+              board: data.board,
+              currentPlayer: data.currentPlayer,
+              gameStatus: data.gameStatus,
+            },
+          })
+        },
+      )
 
       activeSocket.on("gameOver", (data: { winner: PieceColor | "draw" }) => {
         let gameStatus: GameState["gameStatus"] = "draw"


### PR DESCRIPTION
## Summary
- Replace online move handler with SET_GAME_STATE to apply server-provided board, turn, and status

## Testing
- `pnpm run test` *(fails: Missing script: test)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4419b9de083318984241f7d4bb560