### PR TITLE
Handle join game errors

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -24,7 +24,14 @@ export async function joinGame(roomId: string, user: TelegramUser, initData: str
     body: JSON.stringify({ roomId, user, initData }),
   })
   if (!res.ok) {
-    throw new Error("Failed to join game")
+    let message = "Failed to join game"
+    try {
+      const data = await res.json()
+      if (data?.error) message = data.error
+    } catch {
+      // ignore JSON parsing errors
+    }
+    throw new Error(message)
   }
   return res.json()
 }


### PR DESCRIPTION
## Summary
- Show an inline error when joining an online room fails with options to retry or return to the menu
- Surface server error messages from `joinGame` for clearer feedback

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4494a0d9c833188cdaa00df309f72