### PR TITLE
Allow Vercel build dependencies for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,12 @@
     "tailwindcss": "^4.1.9",
     "tw-animate-css": "1.3.3",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp",
+      "@tailwindcss/oxide",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- allow pnpm to build sharp, @tailwindcss/oxide, and unrs-resolver during Vercel builds

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4525d72c883318c78542ef8360b0b